### PR TITLE
Update dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,7 @@
         <dependency>
             <groupId>org.codehaus.plexus</groupId>
             <artifactId>plexus-io</artifactId>
-            <version>2.7</version>
+            <version>3.0.1</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -108,7 +108,7 @@
         <dependency>
             <groupId>org.robotframework</groupId>
             <artifactId>robotframework</artifactId>
-            <version>3.0.2</version>
+            <version>3.0.4</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
This PR updates RobotFramework to 3.0.4 and plexus-io to 3.0.1.

Update of `plexus-io` also makes it possible to run UI tests that use https://github.com/Hi-Fi/robotframework-seleniumlibrary-java with Selenium3 and the latest htmlunit. Prior this commit, all the tests were failing with error `java.lang.NoSuchMethodError: org.apache.commons.io.IOUtils.toString(Ljava/io/InputStream;Ljava/nio/charset/Charset;)Ljava/lang/String;`

This method were introduced in `commons-io` >= 2.3. But this plugin were pulling commons-io of version 2.2 because of the old version of `plexus-io`.