### PR TITLE
acceptance-test goal consoleColors parameter doesn't work

### DIFF
--- a/src/main/java/org/robotframework/mavenplugin/AcceptanceTestMojo.java
+++ b/src/main/java/org/robotframework/mavenplugin/AcceptanceTestMojo.java
@@ -743,6 +743,7 @@ public class AcceptanceTestMojo extends AbstractMojoWithLoadedClasspath {
      * <li>'off' - Colors are disabled</li>
      * </ul>
      *
+     * @parameter
      */
     private String consoleColors;
 


### PR DESCRIPTION
acceptance-test consoleColors parameter is missing the @parameter tag. It was accidentally removed with https://github.com/robotframework/MavenPlugin/commit/52f491101e4fc7465cf3802d10a787ac02afc811

If you feel it's easier to directly commit this one-liner, just go for it.

